### PR TITLE
Properly remove coupon code:

### DIFF
--- a/enum-nypizza.php
+++ b/enum-nypizza.php
@@ -35,6 +35,7 @@ class NewYorkPizzaCouponBrute
          */
         92 => 'Hawaii',
         93 => 'Brooklin Style',
+        97 => 'East Side Shoarma',
         132 => 'Downtown Döner',
         262 => 'Salami',
         // 427 => 'Perfect Peperoni',
@@ -152,7 +153,8 @@ class NewYorkPizzaCouponBrute
     private function removeCoupon(string $couponIdentifier): bool
     {
         $json = $this->request('https://www.newyorkpizza.nl/Order/RemoveCouponFromCurrentOrder', [
-            'couponIdentifier' => $couponIdentifier
+            'couponIdentifier' => $couponIdentifier,
+            'alsoRemoveProducts' => 'false'
             ], true);
 
         $data = json_decode($json, true);


### PR DESCRIPTION
Fix: Coupon code was not properly removed, which caused only one coupon code to be found. Now all possible coupons are found! ^_^